### PR TITLE
Type conversion errors removed and ambiguity of sqrt removed

### DIFF
--- a/README
+++ b/README
@@ -2,3 +2,9 @@ Simple code for hand and finger detection using OpenCV.
 
 Example video:
 http://www.youtube.com/watch?v=9NzmeEml3Wk
+
+
+FORKED FROM  bengal @ https://github.com/bengal/opencv-hand-detection/
+
+Minor changes like error fixes for windows [visual studio] implemented
+<br>Thanks!!

--- a/hand.c
+++ b/hand.c
@@ -108,8 +108,8 @@ void init_ctx(struct ctx *ctx)
 	ctx->contour_st = cvCreateMemStorage(0);
 	ctx->hull_st = cvCreateMemStorage(0);
 	ctx->temp_st = cvCreateMemStorage(0);
-	ctx->fingers = calloc(NUM_FINGERS + 1, sizeof(CvPoint));
-	ctx->defects = calloc(NUM_DEFECTS, sizeof(CvPoint));
+	ctx->fingers = (CvPoint *)calloc(NUM_FINGERS + 1, sizeof(CvPoint));
+	ctx->defects = (CvPoint *)calloc(NUM_DEFECTS, sizeof(CvPoint));
 }
 
 void filter_and_threshold(struct ctx *ctx)
@@ -187,8 +187,7 @@ void find_convex_hull(struct ctx *ctx)
 					     ctx->defects_st);
 
 		if (defects && defects->total) {
-			defect_array = calloc(defects->total,
-					      sizeof(CvConvexityDefect));
+			defect_array = (CvConvexityDefect *)calloc(defects->total,sizeof(CvConvexityDefect));
 			cvCvtSeqToArray(defects, defect_array, CV_WHOLE_SEQ);
 
 			/* Average depth points to get hand center */
@@ -214,7 +213,7 @@ void find_convex_hull(struct ctx *ctx)
 					(y - defect_array[i].depth_point->y) *
 					(y - defect_array[i].depth_point->y);
 
-				dist += sqrt(d);
+				dist += sqrt((float)d);
 			}
 
 			ctx->hand_radius = dist / defects->total;
@@ -237,7 +236,7 @@ void find_fingers(struct ctx *ctx)
 		return;
 
 	n = ctx->contour->total;
-	points = calloc(n, sizeof(CvPoint));
+	points = (CvPoint *)calloc(n, sizeof(CvPoint));
 
 	cvCvtSeqToArray(ctx->contour, points, CV_WHOLE_SEQ);
 


### PR DESCRIPTION
Removed errors found in visual studio 2012
ERROR: error C2440: '=' : cannot convert from 'void *' to 'CvPoint *'  
Some warnings still exist like
warning C4244: '+=' : conversion from 'float' to 'int', possible loss of data  
have a look to that
